### PR TITLE
Fixed server error when item has no parent and added logic to update parent status when new item is created

### DIFF
--- a/AdoStateProcessor/Processor/AdoProcessor.cs
+++ b/AdoStateProcessor/Processor/AdoProcessor.cs
@@ -33,6 +33,9 @@ namespace AdoStateProcessor.Processor
         {
             PayloadViewModel vm = BuildPayloadViewModel(payload);
 
+            if (vm == null)
+                return;
+
             logger.LogTrace(" Masked PAT:" + Mask(pat));
             vm.pat = pat;
             //if the event type is something other the updated, then lets just return an ok

--- a/AdoStateProcessor/Processor/AdoProcessor.cs
+++ b/AdoStateProcessor/Processor/AdoProcessor.cs
@@ -151,7 +151,7 @@ namespace AdoStateProcessor.Processor
             if (!this.PayloadHasValue(body, "resource.rev"))
                 return null;
             else
-                vm.rev = this.GetPayloadValue<int>(body, "resource.rev", token => Convert.ToInt32(body["resource"]["rev"].ToString()));
+                vm.rev = this.GetPayloadValue<int>(body, "resource.rev", token => Convert.ToInt32(token.ToString()));
 
             vm.url = this.GetPayloadValue<string>(body, "resource.url", token => token.ToString());
             if (string.IsNullOrEmpty(vm.url))


### PR DESCRIPTION
When the azure function produces a server error it can happen that the web hook inside devops becomes enable (restricted) and wont run for the next updated work items.
For example it could happen when someone forgets to link a task to a parent user story and updates its status.
Also it happens that i want my user story to become active when the first task is assigned to it, to do that i need a web hook on the "work item created" event and a logic to handle a new item that has not an Id

To avoid the following changes were made:
- Work Item relations could be null if the status of a Work Item without parents is updated, a check has been added
- Improved error logging to detect missing parent errors easly
- Added controls to ensure all parameters are retrieved when payload view model is built
- Changed logic to handle incoming new item without crashing